### PR TITLE
Initialize the new qmk_userspace

### DIFF
--- a/keyboards/ergodox_ez/base/keymaps/jjerrell/default.png.md
+++ b/keyboards/ergodox_ez/base/keymaps/jjerrell/default.png.md
@@ -1,0 +1,1 @@
+https://i.imgur.com/fKX0Zbs.png

--- a/keyboards/ergodox_ez/base/keymaps/jjerrell/default_highres.png.md
+++ b/keyboards/ergodox_ez/base/keymaps/jjerrell/default_highres.png.md
@@ -1,0 +1,1 @@
+https://i.imgur.com/giAc3M9.jpg

--- a/keyboards/ergodox_ez/base/keymaps/jjerrell/keymap.c
+++ b/keyboards/ergodox_ez/base/keymaps/jjerrell/keymap.c
@@ -1,0 +1,200 @@
+#include QMK_KEYBOARD_H
+#include "version.h"
+
+enum layers {
+    BASE,  // default layer
+    SYMB,  // symbols
+    MDIA,  // media keys
+};
+
+enum custom_keycodes {
+    VRSN = SAFE_RANGE,
+};
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+/* Keymap 0: Basic layer
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |   =    |   1  |   2  |   3  |   4  |   5  | LEFT |           | RIGHT|   6  |   7  |   8  |   9  |   0  |   -    |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * | Del    |   Q  |   W  |   E  |   R  |   T  |  L1  |           |  L1  |   Y  |   U  |   I  |   O  |   P  |   \    |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * | BkSp   |   A  |   S  |   D  |   F  |   G  |------|           |------|   H  |   J  |   K  |   L  |; / L2|' / Cmd |
+ * |--------+------+------+------+------+------| Hyper|           | Meh  |------+------+------+------+------+--------|
+ * | LShift |Z/Ctrl|   X  |   C  |   V  |   B  |      |           |      |   N  |   M  |   ,  |   .  |//Ctrl| RShift |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |Grv/L1|  '"  |AltShf| Left | Right|                                       |  Up  | Down |   [  |   ]  | ~L1  |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        | App  | LGui |       | Alt  |Ctrl/Esc|
+ *                                 ,------|------|------|       |------+--------+------.
+ *                                 |      |      | Home |       | PgUp |        |      |
+ *                                 | Space|Backsp|------|       |------|  Tab   |Enter |
+ *                                 |      |ace   | End  |       | PgDn |        |      |
+ *                                 `--------------------'       `----------------------'
+ */
+[BASE] = LAYOUT_ergodox_pretty(
+  // left hand
+  KC_EQL,          KC_1,        KC_2,          KC_3,    KC_4,    KC_5,    KC_LEFT,              KC_RGHT,      KC_6,    KC_7,    KC_8,    KC_9,              KC_0,           KC_MINS,
+  KC_DEL,          KC_Q,        KC_W,          KC_E,    KC_R,    KC_T,    TG(SYMB),             TG(SYMB),     KC_Y,    KC_U,    KC_I,    KC_O,              KC_P,           KC_BSLS,
+  KC_BSPC,         KC_A,        KC_S,          KC_D,    KC_F,    KC_G,                                        KC_H,    KC_J,    KC_K,    KC_L,    LT(MDIA, KC_SCLN), GUI_T(KC_QUOT),
+  KC_LSFT,         CTL_T(KC_Z), KC_X,          KC_C,    KC_V,    KC_B,    ALL_T(KC_NO),                  MEH_T(KC_NO), KC_N,    KC_M,    KC_COMM, KC_DOT,           CTL_T(KC_SLSH), KC_RSFT,
+  LT(SYMB,KC_GRV), KC_QUOT,     LALT(KC_LSFT), KC_LEFT, KC_RGHT,                                              KC_UP,   KC_DOWN, KC_LBRC, KC_RBRC, TT(SYMB),
+                                                           ALT_T(KC_APP), KC_LGUI,                KC_LALT, CTL_T(KC_ESC),
+                                                                          KC_HOME,                 KC_PGUP,
+                                                         KC_SPC, KC_BSPC, KC_END,                  KC_PGDN, KC_TAB, KC_ENT
+),
+/* Keymap 1: Symbol Layer
+ *
+ * ,---------------------------------------------------.           ,--------------------------------------------------.
+ * |Version  |  F1  |  F2  |  F3  |  F4  |  F5  |      |           |      |  F6  |  F7  |  F8  |  F9  |  F10 |   F11  |
+ * |---------+------+------+------+------+------+------|           |------+------+------+------+------+------+--------|
+ * |         |   !  |   @  |   {  |   }  |   |  |      |           |      |   Up |   7  |   8  |   9  |   *  |   F12  |
+ * |---------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |         |   #  |   $  |   (  |   )  |   `  |------|           |------| Down |   4  |   5  |   6  |   +  |        |
+ * |---------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |         |   %  |   ^  |   [  |   ]  |   ~  |      |           |      |   &  |   1  |   2  |   3  |   \  |        |
+ * `---------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   | EPRM  |      |      |      |      |                                       |      |    . |   0  |   =  |      |
+ *   `-----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |Animat|      |       |Toggle|Solid |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |Bright|Bright|      |       |      |Hue-  |Hue+  |
+ *                                 |ness- |ness+ |------|       |------|      |      |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+[SYMB] = LAYOUT_ergodox_pretty(
+  // left hand
+  VRSN,    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_TRNS,     KC_TRNS, KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,
+  KC_TRNS, KC_EXLM, KC_AT,   KC_LCBR, KC_RCBR, KC_PIPE, KC_TRNS,     KC_TRNS, KC_UP,   KC_7,    KC_8,    KC_9,    KC_ASTR, KC_F12,
+  KC_TRNS, KC_HASH, KC_DLR,  KC_LPRN, KC_RPRN, KC_GRV,               KC_DOWN, KC_4,    KC_5,    KC_6,    KC_PLUS, KC_TRNS,
+  KC_TRNS, KC_PERC, KC_CIRC, KC_LBRC, KC_RBRC, KC_TILD, KC_TRNS,     KC_TRNS, KC_AMPR, KC_1,    KC_2,    KC_3,    KC_BSLS, KC_TRNS,
+  EE_CLR,  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,                                         KC_TRNS, KC_DOT,  KC_0,    KC_EQL,  KC_TRNS,
+                                               RGB_MOD, KC_TRNS,     RGB_TOG, RGB_M_P,
+                                                        KC_TRNS,     KC_TRNS,
+                                      RGB_VAD, RGB_VAI, KC_TRNS,     KC_TRNS, RGB_HUD, RGB_HUI
+),
+/* Keymap 2: Media and mouse keys
+ *
+ * ,--------------------------------------------------.           ,--------------------------------------------------.
+ * |        |      |      |      |      |      |      |           |      |      |      |      |      |      |        |
+ * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+ * |        |      |      | MsUp |      |      |      |           |      |      |      |      |      |      |        |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |      |MsLeft|MsDown|MsRght|      |------|           |------|      |      |      |      |      |  Play  |
+ * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+ * |        |      |      |      |      |      |      |           |      |      |      | Prev | Next |      |        |
+ * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+ *   |      |      |      | Lclk | Rclk |                                       |VolUp |VolDn | Mute |      |      |
+ *   `----------------------------------'                                       `----------------------------------'
+ *                                        ,-------------.       ,-------------.
+ *                                        |      |      |       |      |      |
+ *                                 ,------|------|------|       |------+------+------.
+ *                                 |      |      |      |       |      |      |Brwser|
+ *                                 |      |      |------|       |------|      |Back  |
+ *                                 |      |      |      |       |      |      |      |
+ *                                 `--------------------'       `--------------------'
+ */
+[MDIA] = LAYOUT_ergodox_pretty(
+  // left hand
+  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+  KC_TRNS, KC_TRNS, KC_TRNS, KC_MS_U, KC_TRNS, KC_TRNS, KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
+  KC_TRNS, KC_TRNS, KC_MS_L, KC_MS_D, KC_MS_R, KC_TRNS,                       KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_MPLY,
+  KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,     KC_TRNS, KC_TRNS, KC_TRNS, KC_MPRV, KC_MNXT, KC_TRNS, KC_TRNS,
+  KC_TRNS, KC_TRNS, KC_TRNS, KC_BTN1, KC_BTN2,                                         KC_VOLU, KC_VOLD, KC_MUTE, KC_TRNS, KC_TRNS,
+
+                                               KC_TRNS, KC_TRNS,     KC_TRNS, KC_TRNS,
+                                                        KC_TRNS,     KC_TRNS,
+                                      KC_TRNS, KC_TRNS, KC_TRNS,     KC_TRNS, KC_TRNS, KC_WBAK
+),
+};
+// clang-format on
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    if (record->event.pressed) {
+        switch (keycode) {
+            case VRSN:
+                SEND_STRING(QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION);
+                return false;
+        }
+    }
+    return true;
+}
+
+// Runs just one time when the keyboard initializes.
+void keyboard_post_init_user(void) {
+#ifdef RGBLIGHT_COLOR_LAYER_0
+    rgblight_setrgb(RGBLIGHT_COLOR_LAYER_0);
+#endif
+};
+
+// Runs whenever there is a layer state change.
+layer_state_t layer_state_set_user(layer_state_t state) {
+    ergodox_board_led_off();
+    ergodox_right_led_1_off();
+    ergodox_right_led_2_off();
+    ergodox_right_led_3_off();
+
+    uint8_t layer = get_highest_layer(state);
+    switch (layer) {
+        case 0:
+#ifdef RGBLIGHT_COLOR_LAYER_0
+            rgblight_setrgb(RGBLIGHT_COLOR_LAYER_0);
+#endif
+            break;
+        case 1:
+            ergodox_right_led_1_on();
+#ifdef RGBLIGHT_COLOR_LAYER_1
+            rgblight_setrgb(RGBLIGHT_COLOR_LAYER_1);
+#endif
+            break;
+        case 2:
+            ergodox_right_led_2_on();
+#ifdef RGBLIGHT_COLOR_LAYER_2
+            rgblight_setrgb(RGBLIGHT_COLOR_LAYER_2);
+#endif
+            break;
+        case 3:
+            ergodox_right_led_3_on();
+#ifdef RGBLIGHT_COLOR_LAYER_3
+            rgblight_setrgb(RGBLIGHT_COLOR_LAYER_3);
+#endif
+            break;
+        case 4:
+            ergodox_right_led_1_on();
+            ergodox_right_led_2_on();
+#ifdef RGBLIGHT_COLOR_LAYER_4
+            rgblight_setrgb(RGBLIGHT_COLOR_LAYER_4);
+#endif
+            break;
+        case 5:
+            ergodox_right_led_1_on();
+            ergodox_right_led_3_on();
+#ifdef RGBLIGHT_COLOR_LAYER_5
+            rgblight_setrgb(RGBLIGHT_COLOR_LAYER_5);
+#endif
+            break;
+        case 6:
+            ergodox_right_led_2_on();
+            ergodox_right_led_3_on();
+#ifdef RGBLIGHT_COLOR_LAYER_6
+            rgblight_setrgb(RGBLIGHT_COLOR_LAYER_6);
+#endif
+            break;
+        case 7:
+            ergodox_right_led_1_on();
+            ergodox_right_led_2_on();
+            ergodox_right_led_3_on();
+#ifdef RGBLIGHT_COLOR_LAYER_7
+            rgblight_setrgb(RGBLIGHT_COLOR_LAYER_7);
+#endif
+            break;
+        default:
+            break;
+    }
+
+    return state;
+};

--- a/keyboards/ergodox_ez/base/keymaps/jjerrell/readme.md
+++ b/keyboards/ergodox_ez/base/keymaps/jjerrell/readme.md
@@ -1,0 +1,15 @@
+# ErgoDox EZ Default Configuration
+
+## Changelog
+
+* Dec 2016:
+  * Added LED keys
+  * Refreshed layout graphic, comes from http://configure.ergodox-ez.com now.
+* Sep 22, 2016:
+  * Created a new key in layer 1 (bottom-corner key) that resets the EEPROM.
+* Feb 2, 2016 (V1.1): 
+  * Made the right-hand quote key double as Cmd/Win on hold. So you get ' when you tap it, " when you tap it with Shift, and Cmd or Win when you hold it. You can then use it as a modifier, or just press and hold it for a moment (and then let go) to send a single Cmd or Win keystroke (handy for opening the Start menu on Windows).
+
+This is what we ship with out of the factory. :) The image says it all:
+
+![Default](https://i.imgur.com/Be53jH7.png)

--- a/keyboards/moonlander/keymaps/jjerrell/config.h
+++ b/keyboards/moonlander/keymaps/jjerrell/config.h
@@ -1,0 +1,21 @@
+/* Copyright 2020 ZSA Technology Labs, Inc <@zsa>
+ * Copyright 2020 Jack Humbert <jack.humb@gmail.com>
+ * Copyright 2020 Christopher Courtney, aka Drashna Jael're  (@drashna) <drashna@live.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define ORYX_CONFIGURATOR

--- a/keyboards/moonlander/keymaps/jjerrell/keymap.c
+++ b/keyboards/moonlander/keymaps/jjerrell/keymap.c
@@ -1,0 +1,73 @@
+/* Copyright 2020 ZSA Technology Labs, Inc <@zsa>
+ * Copyright 2020 Jack Humbert <jack.humb@gmail.com>
+ * Copyright 2020 Christopher Courtney, aka Drashna Jael're  (@drashna) <drashna@live.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+#include QMK_KEYBOARD_H
+#include "version.h"
+
+enum layers {
+    BASE,  // default layer
+    SYMB,  // symbols
+    MDIA,  // media keys
+};
+
+enum custom_keycodes {
+    VRSN = SAFE_RANGE,
+};
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [BASE] = LAYOUT(
+        KC_EQL,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_LEFT,           KC_RGHT, KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS,
+        KC_DEL,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    TG(SYMB),         TG(SYMB), KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSLS,
+        KC_BSPC, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_HYPR,           KC_MEH,  KC_H,    KC_J,    KC_K,    KC_L,    LT(MDIA, KC_SCLN), LGUI_T(KC_QUOT),
+        KC_LSFT, LCTL_T(KC_Z),KC_X,KC_C,    KC_V,    KC_B,                                KC_N,    KC_M,    KC_COMM, KC_DOT,  RCTL_T(KC_SLSH), KC_RSFT,
+    LT(SYMB,KC_GRV),WEBUSB_PAIR,A(KC_LSFT),KC_LEFT, KC_RGHT,  LALT_T(KC_APP),    RCTL_T(KC_ESC),   KC_UP,   KC_DOWN, KC_LBRC, KC_RBRC, MO(SYMB),
+                                            KC_SPC,  KC_BSPC, KC_LGUI,           KC_LALT,  KC_TAB,  KC_ENT
+    ),
+
+    [SYMB] = LAYOUT(
+        VRSN,    KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   _______,           _______, KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,
+        _______, KC_EXLM, KC_AT,   KC_LCBR, KC_RCBR, KC_PIPE, _______,           _______, KC_UP,   KC_7,    KC_8,    KC_9,    KC_ASTR, KC_F12,
+        _______, KC_HASH, KC_DLR,  KC_LPRN, KC_RPRN, KC_GRV,  _______,           _______, KC_DOWN, KC_4,    KC_5,    KC_6,    KC_PLUS, _______,
+        _______, KC_PERC, KC_CIRC, KC_LBRC, KC_RBRC, KC_TILD,                             KC_AMPR, KC_1,    KC_2,    KC_3,    KC_BSLS, _______,
+        EE_CLR,  _______, _______, _______, _______,          RGB_VAI,           RGB_TOG,          _______, KC_DOT,  KC_0,    KC_EQL,  _______,
+                                            RGB_HUD, RGB_VAD, RGB_HUI, TOGGLE_LAYER_COLOR,_______, _______
+    ),
+
+    [MDIA] = LAYOUT(
+        LED_LEVEL,_______,_______, _______, _______, _______, _______,           _______, _______, _______, _______, _______, _______, QK_BOOT,
+        _______, _______, _______, KC_MS_U, _______, _______, _______,           _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, KC_MS_L, KC_MS_D, KC_MS_R, _______, _______,           _______, _______, _______, _______, _______, _______, KC_MPLY,
+        _______, _______, _______, _______, _______, _______,                             _______, _______, KC_MPRV, KC_MNXT, _______, _______,
+        _______, _______, _______, KC_BTN1, KC_BTN2,         _______,            _______,          KC_VOLU, KC_VOLD, KC_MUTE, _______, _______,
+                                            _______, _______, _______,           _______, _______, _______
+    ),
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    if (record->event.pressed) {
+        switch (keycode) {
+        case VRSN:
+            SEND_STRING (QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION);
+            return false;
+        }
+    }
+    return true;
+}

--- a/keyboards/planck/ez/glow/keymaps/jjerrell/config.h
+++ b/keyboards/planck/ez/glow/keymaps/jjerrell/config.h
@@ -1,0 +1,49 @@
+/* Copyright 2015-2021 Jack Humbert
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef AUDIO_ENABLE
+#    define STARTUP_SONG SONG(PLANCK_SOUND)
+// #define STARTUP_SONG SONG(NO_SOUND)
+
+#    define DEFAULT_LAYER_SONGS \
+        { SONG(QWERTY_SOUND), SONG(COLEMAK_SOUND), SONG(DVORAK_SOUND) }
+#endif
+
+/*
+ * MIDI options
+ */
+
+/* enable basic MIDI features:
+   - MIDI notes can be sent when in Music mode is on
+*/
+
+#define MIDI_BASIC
+
+/* enable advanced MIDI features:
+   - MIDI notes can be added to the keymap
+   - Octave shift and transpose
+   - Virtual sustain, portamento, and modulation wheel
+   - etc.
+*/
+//#define MIDI_ADVANCED
+
+/* override number of MIDI tone keycodes (each octave adds 12 keycodes and allocates 12 bytes) */
+//#define MIDI_TONE_KEYCODE_OCTAVES 2
+
+// Most tactile encoders have detents every 4 stages
+#define ENCODER_RESOLUTION 4

--- a/keyboards/planck/ez/glow/keymaps/jjerrell/keymap.c
+++ b/keyboards/planck/ez/glow/keymaps/jjerrell/keymap.c
@@ -1,0 +1,355 @@
+/* Copyright 2015-2021 Jack Humbert
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+
+#ifdef AUDIO_ENABLE
+#    include "muse.h"
+#endif
+
+enum planck_layers {
+  _QWERTY,
+  _COLEMAK,
+  _DVORAK,
+  _LOWER,
+  _RAISE,
+  _PLOVER,
+  _ADJUST
+};
+
+enum planck_keycodes {
+  QWERTY = SAFE_RANGE,
+  COLEMAK,
+  DVORAK,
+  PLOVER,
+  BACKLIT,
+  EXT_PLV
+};
+
+#define LOWER MO(_LOWER)
+#define RAISE MO(_RAISE)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+/* Qwerty
+ * ,-----------------------------------------------------------------------------------.
+ * | Tab  |   Q  |   W  |   E  |   R  |   T  |   Y  |   U  |   I  |   O  |   P  | Bksp |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Esc  |   A  |   S  |   D  |   F  |   G  |   H  |   J  |   K  |   L  |   ;  |  '   |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Shift|   Z  |   X  |   C  |   V  |   B  |   N  |   M  |   ,  |   .  |   /  |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Brite| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_QWERTY] = LAYOUT_planck_grid(
+    KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_BSPC,
+    KC_ESC,  KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT ,
+    BACKLIT, KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  KC_SPC,  RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
+),
+
+/* Colemak
+ * ,-----------------------------------------------------------------------------------.
+ * | Tab  |   Q  |   W  |   F  |   P  |   G  |   J  |   L  |   U  |   Y  |   ;  | Bksp |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Esc  |   A  |   R  |   S  |   T  |   D  |   H  |   N  |   E  |   I  |   O  |  '   |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Shift|   Z  |   X  |   C  |   V  |   B  |   K  |   M  |   ,  |   .  |   /  |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Brite| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_COLEMAK] = LAYOUT_planck_grid(
+    KC_TAB,  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,    KC_J,    KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_BSPC,
+    KC_ESC,  KC_A,    KC_R,    KC_S,    KC_T,    KC_D,    KC_H,    KC_N,    KC_E,    KC_I,    KC_O,    KC_QUOT,
+    KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_K,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_ENT ,
+    BACKLIT, KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  KC_SPC,  RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
+),
+
+/* Dvorak
+ * ,-----------------------------------------------------------------------------------.
+ * | Tab  |   '  |   ,  |   .  |   P  |   Y  |   F  |   G  |   C  |   R  |   L  | Bksp |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Esc  |   A  |   O  |   E  |   U  |   I  |   D  |   H  |   T  |   N  |   S  |  /   |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Shift|   ;  |   Q  |   J  |   K  |   X  |   B  |   M  |   W  |   V  |   Z  |Enter |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Brite| Ctrl | Alt  | GUI  |Lower |    Space    |Raise | Left | Down |  Up  |Right |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_DVORAK] = LAYOUT_planck_grid(
+    KC_TAB,  KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y,    KC_F,    KC_G,    KC_C,    KC_R,    KC_L,    KC_BSPC,
+    KC_ESC,  KC_A,    KC_O,    KC_E,    KC_U,    KC_I,    KC_D,    KC_H,    KC_T,    KC_N,    KC_S,    KC_SLSH,
+    KC_LSFT, KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X,    KC_B,    KC_M,    KC_W,    KC_V,    KC_Z,    KC_ENT ,
+    BACKLIT, KC_LCTL, KC_LALT, KC_LGUI, LOWER,   KC_SPC,  KC_SPC,  RAISE,   KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT
+),
+
+/* Lower
+ * ,-----------------------------------------------------------------------------------.
+ * |   ~  |   !  |   @  |   #  |   $  |   %  |   ^  |   &  |   *  |   (  |   )  | Bksp |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   _  |   +  |   {  |   }  |  |   |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO ~ |ISO | | Home | End  |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_LOWER] = LAYOUT_planck_grid(
+    KC_TILD, KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_CIRC, KC_AMPR,    KC_ASTR,    KC_LPRN, KC_RPRN, KC_BSPC,
+    KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_UNDS,    KC_PLUS,    KC_LCBR, KC_RCBR, KC_PIPE,
+    _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  S(KC_NUHS), S(KC_NUBS), KC_HOME, KC_END,  _______,
+    _______, _______, _______, _______, _______, _______, _______, _______,    KC_MNXT,    KC_VOLD, KC_VOLU, KC_MPLY
+),
+
+/* Raise
+ * ,-----------------------------------------------------------------------------------.
+ * |   `  |   1  |   2  |   3  |   4  |   5  |   6  |   7  |   8  |   9  |   0  | Bksp |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Del  |  F1  |  F2  |  F3  |  F4  |  F5  |  F6  |   -  |   =  |   [  |   ]  |  \   |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |  F7  |  F8  |  F9  |  F10 |  F11 |  F12 |ISO # |ISO / |Pg Up |Pg Dn |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      | Next | Vol- | Vol+ | Play |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_RAISE] = LAYOUT_planck_grid(
+    KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_BSPC,
+    KC_DEL,  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, KC_BSLS,
+    _______, KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,  KC_NUHS, KC_NUBS, KC_PGUP, KC_PGDN, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, KC_MNXT, KC_VOLD, KC_VOLU, KC_MPLY
+),
+
+/* Plover layer (http://opensteno.org)
+ * ,-----------------------------------------------------------------------------------.
+ * |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |   #  |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |   S  |   T  |   P  |   H  |   *  |   *  |   F  |   P  |   L  |   T  |   D  |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |   S  |   K  |   W  |   R  |   *  |   *  |   R  |   B  |   G  |   S  |   Z  |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * | Exit |      |      |   A  |   O  |             |   E  |   U  |      |      |      |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_PLOVER] = LAYOUT_planck_grid(
+    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1,    KC_1   ,
+    XXXXXXX, KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC,
+    XXXXXXX, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,
+    EXT_PLV, XXXXXXX, XXXXXXX, KC_C,    KC_V,    XXXXXXX, XXXXXXX, KC_N,    KC_M,    XXXXXXX, XXXXXXX, XXXXXXX
+),
+
+/* Adjust (Lower + Raise)
+ *                      v------------------------RGB CONTROL--------------------v
+ * ,-----------------------------------------------------------------------------------.
+ * |      | Reset|Debug | RGB  |RGBMOD| HUE+ | HUE- | SAT+ | SAT- |BRGTH+|BRGTH-|  Del |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |MUSmod|Aud on|Audoff|AGnorm|AGswap|Qwerty|Colemk|Dvorak|Plover|      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |Voice-|Voice+|Mus on|Musoff|MIDIon|MIDIof|      |      |      |      |      |
+ * |------+------+------+------+------+------+------+------+------+------+------+------|
+ * |      |      |      |      |      |             |      |      |      |      |      |
+ * `-----------------------------------------------------------------------------------'
+ */
+[_ADJUST] = LAYOUT_planck_grid(
+    _______, QK_BOOT, DB_TOGG, RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, KC_DEL ,
+    _______, _______, MU_NEXT, AU_ON,   AU_OFF,  AG_NORM, AG_SWAP, QWERTY,  COLEMAK, DVORAK,  PLOVER,  _______,
+    _______, AU_PREV, AU_NEXT, MU_ON,   MU_OFF,  MI_ON,   MI_OFF,  _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______
+)
+
+};
+
+#ifdef AUDIO_ENABLE
+  float plover_song[][2]     = SONG(PLOVER_SOUND);
+  float plover_gb_song[][2]  = SONG(PLOVER_GOODBYE_SOUND);
+#endif
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+  return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case QWERTY:
+      if (record->event.pressed) {
+        print("mode just switched to qwerty and this is a huge string\n");
+        set_single_persistent_default_layer(_QWERTY);
+      }
+      return false;
+      break;
+    case COLEMAK:
+      if (record->event.pressed) {
+        set_single_persistent_default_layer(_COLEMAK);
+      }
+      return false;
+      break;
+    case DVORAK:
+      if (record->event.pressed) {
+        set_single_persistent_default_layer(_DVORAK);
+      }
+      return false;
+      break;
+    case BACKLIT:
+      if (record->event.pressed) {
+        register_code(KC_RSFT);
+        #ifdef BACKLIGHT_ENABLE
+          backlight_step();
+        #endif
+        #ifdef KEYBOARD_planck_rev5
+          writePinLow(E6);
+        #endif
+      } else {
+        unregister_code(KC_RSFT);
+        #ifdef KEYBOARD_planck_rev5
+          writePinHigh(E6);
+        #endif
+      }
+      return false;
+      break;
+    case PLOVER:
+      if (record->event.pressed) {
+        #ifdef AUDIO_ENABLE
+          stop_all_notes();
+          PLAY_SONG(plover_song);
+        #endif
+        layer_off(_RAISE);
+        layer_off(_LOWER);
+        layer_off(_ADJUST);
+        layer_on(_PLOVER);
+        if (!eeconfig_is_enabled()) {
+            eeconfig_init();
+        }
+        keymap_config.raw = eeconfig_read_keymap();
+        keymap_config.nkro = 1;
+        eeconfig_update_keymap(keymap_config.raw);
+      }
+      return false;
+      break;
+    case EXT_PLV:
+      if (record->event.pressed) {
+        #ifdef AUDIO_ENABLE
+          PLAY_SONG(plover_gb_song);
+        #endif
+        layer_off(_PLOVER);
+      }
+      return false;
+      break;
+  }
+  return true;
+}
+
+bool muse_mode = false;
+uint8_t last_muse_note = 0;
+uint16_t muse_counter = 0;
+uint8_t muse_offset = 70;
+uint16_t muse_tempo = 50;
+
+bool encoder_update_user(uint8_t index, bool clockwise) {
+  if (muse_mode) {
+    if (IS_LAYER_ON(_RAISE)) {
+      if (clockwise) {
+        muse_offset++;
+      } else {
+        muse_offset--;
+      }
+    } else {
+      if (clockwise) {
+        muse_tempo+=1;
+      } else {
+        muse_tempo-=1;
+      }
+    }
+  } else {
+    if (clockwise) {
+      #ifdef MOUSEKEY_ENABLE
+        tap_code(KC_MS_WH_DOWN);
+      #else
+        tap_code(KC_PGDN);
+      #endif
+    } else {
+      #ifdef MOUSEKEY_ENABLE
+        tap_code(KC_MS_WH_UP);
+      #else
+        tap_code(KC_PGUP);
+      #endif
+    }
+  }
+    return true;
+}
+
+bool dip_switch_update_user(uint8_t index, bool active) {
+    switch (index) {
+        case 0: {
+#ifdef AUDIO_ENABLE
+            static bool play_sound = false;
+#endif
+            if (active) {
+#ifdef AUDIO_ENABLE
+                if (play_sound) { PLAY_SONG(plover_song); }
+#endif
+                layer_on(_ADJUST);
+            } else {
+#ifdef AUDIO_ENABLE
+                if (play_sound) { PLAY_SONG(plover_gb_song); }
+#endif
+                layer_off(_ADJUST);
+            }
+#ifdef AUDIO_ENABLE
+            play_sound = true;
+#endif
+            break;
+        }
+        case 1:
+            if (active) {
+                muse_mode = true;
+            } else {
+                muse_mode = false;
+            }
+    }
+    return true;
+}
+
+void matrix_scan_user(void) {
+#ifdef AUDIO_ENABLE
+    if (muse_mode) {
+        if (muse_counter == 0) {
+            uint8_t muse_note = muse_offset + SCALE[muse_clock_pulse()];
+            if (muse_note != last_muse_note) {
+                stop_note(compute_freq_for_midi_note(last_muse_note));
+                play_note(compute_freq_for_midi_note(muse_note), 0xF);
+                last_muse_note = muse_note;
+            }
+        }
+        muse_counter = (muse_counter + 1) % muse_tempo;
+    } else {
+        if (muse_counter) {
+            stop_all_notes();
+            muse_counter = 0;
+        }
+    }
+#endif
+}
+
+bool music_mask_user(uint16_t keycode) {
+  switch (keycode) {
+    case RAISE:
+    case LOWER:
+      return false;
+    default:
+      return true;
+  }
+}

--- a/keyboards/planck/ez/glow/keymaps/jjerrell/readme.md
+++ b/keyboards/planck/ez/glow/keymaps/jjerrell/readme.md
@@ -1,0 +1,2 @@
+# The Default Planck Layout
+

--- a/keyboards/planck/ez/glow/keymaps/jjerrell/rules.mk
+++ b/keyboards/planck/ez/glow/keymaps/jjerrell/rules.mk
@@ -1,0 +1,3 @@
+ifeq ($(strip $(AUDIO_ENABLE)), yes)
+    SRC += muse.c
+endif

--- a/qmk.json
+++ b/qmk.json
@@ -1,4 +1,8 @@
 {
     "userspace_version": "1.0",
-    "build_targets": []
+    "build_targets": [
+        ["planck/ez/glow", "jjerrell"],
+        ["moonlander", "jjerrell"],
+        ["ergodox_ez/base", "jjerrell"]
+    ]
 }

--- a/users/jjerrell/config.h
+++ b/users/jjerrell/config.h
@@ -1,0 +1,39 @@
+// Copyright (C) 2023 Jerrell, Jacob <@jjerrell>
+//
+// This file is part of qmk_firmware.
+//
+// qmk_firmware is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// qmk_firmware is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with qmk_firmware.  If not, see <http://www.gnu.org/licenses/>.
+
+#define LEADER_TIMEOUT 250
+#define LEADER_PER_KEY_TIMING
+
+#if defined(TAP_CODE_DELAY)
+#    undef TAP_CODE_DELAY
+#endif
+#define TAP_CODE_DELAY 20
+
+#ifdef RGB_MATRIX_ENABLE
+#   define RGBLIGHT_SLEEP  // enable rgblight_suspend() and rgblight_wakeup() in keymap.c
+#   define RGBLIGHT_TIMEOUT 6000  // ms to wait until rgblight time out
+#endif // RGB_MATRIX_ENABLE
+
+// Space savers
+#undef LOCKING_SUPPORT_ENABLE
+#undef LOCKING_RESYNC_ENABLE
+
+#define NO_ACTION_ONESHOT
+
+#define NO_MUSIC_MODE
+
+// https://docs.qmk.fm/#/feature_secure?id=secure

--- a/users/jjerrell/jjerrell.c
+++ b/users/jjerrell/jjerrell.c
@@ -1,0 +1,158 @@
+// Copyright (C) 2023 Jerrell, Jacob <@jjerrell>
+//
+// This file is part of qmk_firmware.
+//
+// qmk_firmware is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// qmk_firmware is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with qmk_firmware.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "jjerrell.h"
+
+uint16_t copy_paste_timer = 0;
+
+// Matrix scan
+__attribute__((weak)) void matrix_scan_keymap(void) {}
+__attribute__((weak)) void matrix_scan_secret(void) {}
+
+void matrix_scan_user(void) {
+#ifndef NO_SECRETS
+    matrix_scan_secret();
+#endif
+    matrix_scan_keymap();
+}
+
+// Leader start
+__attribute__((weak)) void leader_start_keymap(void) {}
+__attribute__((weak)) void leader_start_secret(void) {}
+
+void leader_start_user(void) {
+#ifndef NO_SECRETS
+    leader_start_secret();
+#endif
+    leader_start_keymap();
+}
+
+// Leader end
+__attribute__((weak)) bool leader_end_keymap(void) {
+    return false;
+}
+__attribute__((weak)) bool leader_end_secret(void) {
+    return false;
+}
+
+void leader_end_user(void) {
+    // only run the process if the keymap or secret implementation did not find a match
+    if (!(leader_end_keymap() || leader_end_secret())) {
+        if (leader_sequence_one_key(KC_R)) {
+            // Rebuild / Run
+            SEND_STRING(SS_LGUI("r"));
+        } else if (leader_sequence_two_keys(KC_B, KC_D)) {
+            // Build info
+            send_string_with_delay_P(PSTR(QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION " Built at: " QMK_BUILDDATE), TAP_CODE_DELAY);
+        }
+    }
+}
+
+// Process record
+__attribute__((weak)) bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
+    return true;
+}
+
+__attribute__((weak)) bool process_record_secrets(uint16_t keycode, keyrecord_t *record) {
+    return true;
+}
+
+/* 
+    Fixes an issue with shifted keycodes being wrapped with MOD_T functions on the _RAISE layers.
+    See https://docs.qmk.fm/#/mod_tap?id=intercepting-mod-taps for more info
+*/
+bool process_record_mod_intercept(uint16_t keycode, keyrecord_t *record) {
+    // this could be a switch by getting highest layer if this becomes problematic on other layers
+    if (IS_LAYER_ON(_RAISE)) {
+        switch (keycode) {
+            case CTL_T(KC_HASH):
+            case GUI_T(KC_LPRN):
+            case ALT_T(KC_RPRN):
+            case ALT_T(KC_LCBR):
+            case GUI_T(KC_RCBR):
+            case CTL_T(KC_CIRC):
+                // Check tap.count to make sure we aren't processing a modifier
+                if (record->tap.count && record->event.pressed) {
+                    // Apply shift
+                    register_code(KC_LSFT);
+                    // Using tap_code16 we can send the uint16_t keycode parameter
+                    tap_code16(keycode);
+                    // Release shift
+                    unregister_code(KC_LSFT);
+                    // stop processing this keycode or the firmware will send the unshifted keycode also
+                    return false;
+                }
+                // Modifier processing or not enough time elapsed to determine if it's a tap
+                break;
+        }
+    }
+    return true;
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    if (process_record_keymap(keycode, record) && process_record_secrets(keycode, record) && process_record_mod_intercept(keycode, record)) {
+        switch (keycode) {
+            case KC_ARROW:
+                if (record->event.pressed) {
+                    SEND_STRING("->");
+                }
+                return false;
+            case KC_MAKE:
+                if (record->event.pressed) {
+                    send_string_with_delay_P(PSTR("qmk compile -kb " QMK_KEYBOARD " -km " QMK_KEYMAP), TAP_CODE_DELAY);
+                    send_string_with_delay_P(PSTR(SS_TAP(X_ENTER)), TAP_CODE_DELAY);
+                }
+                return false;
+            case KC_VRSN:
+                if (record->event.pressed) {
+                    send_string_with_delay_P(PSTR(QMK_KEYBOARD "/" QMK_KEYMAP " @ " QMK_VERSION " Built at: " QMK_BUILDDATE), TAP_CODE_DELAY);
+                }
+                return false;
+            case KC_CCCV: // One key copy/paste
+                if (record->event.pressed) {
+                    copy_paste_timer = timer_read();
+                } else if (timer_elapsed(copy_paste_timer) > TAPPING_TERM) {
+                    // Hold, copy
+                    SEND_STRING(SS_LGUI("c"));
+                } else {
+                    // Tap, paste
+                    SEND_STRING(SS_LGUI("v"));
+                }
+                return false;
+            default:
+                return true;
+        }
+    } else {
+        return false;
+    }
+}
+
+// layer states
+__attribute__((weak)) layer_state_t layer_state_set_keymap(layer_state_t state) {
+    return state;
+}
+
+layer_state_t layer_state_set_user(layer_state_t state) {
+    state = update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
+    return layer_state_set_keymap(state);
+}
+
+__attribute__((weak)) void housekeeping_task_keymap(void) {}
+
+void housekeeping_task_user(void) {
+    housekeeping_task_keymap();
+}

--- a/users/jjerrell/jjerrell.h
+++ b/users/jjerrell/jjerrell.h
@@ -1,0 +1,69 @@
+// Copyright (C) 2023 Jerrell, Jacob <@jjerrell>
+//
+// This file is part of qmk_firmware.
+//
+// qmk_firmware is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// qmk_firmware is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with qmk_firmware.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+#include QMK_KEYBOARD_H
+
+#include "version.h"
+#include "leader.h"
+#include "wrappers.h"
+
+// clang-format off
+enum userspace_layers {
+    _WORKMAN,
+    _QWERTY = 0,
+    _LOWER,
+    _RAISE,
+    _ADJUST,
+    _SPECIAL,
+    _GAME,
+    LAYER_SAFE_RANGE
+};
+
+enum userspace_keycodes {
+    KC_ARROW = QK_USER, // ->
+    KC_MAKE,            // Runs the keyboard's make command
+    KC_VRSN,            // Print QMK Firmware and board info
+    KC_CCCV,
+    USER_SAFE_RANGE
+};
+// clang-format on
+
+#define KC_QWERTY DF(_QWERTY)
+#define KC_WRKMAN DF(_WORKMAN)
+
+#define KC_GAME TG(_GAME)
+#define KC_LOWR MO(_LOWER)
+#define KC_RISE MO(_RAISE)
+
+// Keymap and other callbacks
+void matrix_scan_keymap(void);
+void matrix_scan_secret(void);
+
+void leader_start_keymap(void);
+void leader_start_secret(void);
+
+bool leader_end_keymap(void);
+bool leader_end_secret(void);
+
+bool process_record_keymap(uint16_t keycode, keyrecord_t *record);
+bool process_record_secrets(uint16_t keycode, keyrecord_t *record);
+
+bool rgb_matrix_indicators_advanced_keymap(uint8_t led_min, uint8_t led_max);
+layer_state_t layer_state_set_keymap(layer_state_t state);
+
+void housekeeping_task_keymap(void);

--- a/users/jjerrell/lighting/rgb_custom.c
+++ b/users/jjerrell/lighting/rgb_custom.c
@@ -1,0 +1,98 @@
+// Copyright (C) 2023 Jerrell, Jacob <@jjerrell>
+//
+// This file is part of qmk_firmware.
+//
+// qmk_firmware is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// qmk_firmware is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with qmk_firmware.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "rgb_custom.h"
+
+__attribute__((weak)) bool rgb_indicators_process_keymap(uint8_t led_min, uint8_t led_max) {
+    rgb_matrix_set_color_all(RGB_OFF);
+    return true;
+}
+
+bool rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
+    uint8_t active_mods   = get_mods();
+    uint8_t highest_layer = get_highest_layer(layer_state);
+    return rgb_indicators_process_keymap(led_min, led_max) && rgb_indicators_process_layer_user(highest_layer, active_mods);
+}
+
+__attribute__((weak)) bool rgb_indicators_process_modifiers_keymap(uint8_t active_mods, uint8_t layer) {
+    return true;
+}
+
+bool rgb_indicators_process_modifiers_user(uint8_t active_mods, uint8_t layer) {
+    if (rgb_indicators_process_modifiers_keymap(active_mods, layer)) {
+        for (uint8_t i = 0; i < ARRAY_SIZE(RGB_LIST_MODIFIERS); i++) {
+            if (i == INDEX_CWORD) {
+                continue;
+            }
+            rgb_matrix_set_color(RGB_LIST_MODIFIERS[i], RGB_GOLD);
+        }
+
+        // process modifiers
+        if (active_mods & MOD_MASK_CTRL) {
+            rgb_matrix_set_color(RGB_LIST_MODIFIERS[INDEX_LCTL], RGB_RED);
+            rgb_matrix_set_color(RGB_LIST_MODIFIERS[INDEX_RCTL], RGB_RED);
+        }
+
+        if (active_mods & MOD_MASK_SHIFT || is_caps_word_on()) {
+            if (is_caps_word_on()) {
+                rgb_matrix_set_color(RGB_LIST_MODIFIERS[INDEX_CWORD], RGB_RED);
+            }
+            rgb_matrix_set_color(RGB_LIST_MODIFIERS[INDEX_LSFT], RGB_RED);
+            rgb_matrix_set_color(RGB_LIST_MODIFIERS[INDEX_RSFT], RGB_RED);
+        }
+
+        if (active_mods & MOD_MASK_ALT) {
+            rgb_matrix_set_color(RGB_LIST_MODIFIERS[INDEX_LOPT], RGB_RED);
+            rgb_matrix_set_color(RGB_LIST_MODIFIERS[INDEX_ROPT], RGB_RED);
+        }
+
+        if (active_mods & MOD_MASK_GUI) {
+            rgb_matrix_set_color(RGB_LIST_MODIFIERS[INDEX_LCMD], RGB_RED);
+            rgb_matrix_set_color(RGB_LIST_MODIFIERS[INDEX_RCMD], RGB_RED);
+        }
+    }
+    return true;
+}
+
+bool rgb_indicators_process_layer_user(uint8_t layer, uint8_t active_mods) {
+    switch (layer) {
+        case 0:
+            return rgb_indicators_process_modifiers_user(active_mods, layer);
+            break;
+        case _LOWER:
+            // Arrow keys
+            for (uint8_t i = 0; i < ARRAY_SIZE(RGB_LIST_ARROWS); i++) {
+                if (active_mods & MOD_MASK_SHIFT) {
+                    rgb_matrix_set_color(RGB_LIST_ARROWS[i], RGB_RED);
+                } else {
+                    rgb_matrix_set_color(RGB_LIST_ARROWS[i], RGB_WHITE);
+                }
+            }
+            // Numpad
+            for (uint8_t i = 0; i < ARRAY_SIZE(RGB_LIST_NUMPAD); i++) {
+                if (active_mods & MOD_MASK_SHIFT) {
+                    rgb_matrix_set_color(RGB_LIST_NUMPAD[i], RGB_TEAL);
+                } else {
+                    rgb_matrix_set_color(RGB_LIST_NUMPAD[i], RGB_GREEN);
+                }
+            }
+            break;
+        default:
+            break;
+    }
+    return true;
+}

--- a/users/jjerrell/lighting/rgb_custom.h
+++ b/users/jjerrell/lighting/rgb_custom.h
@@ -1,0 +1,113 @@
+// Copyright (C) 2023 Jerrell, Jacob <@jjerrell>
+//
+// This file is part of qmk_firmware.
+//
+// qmk_firmware is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// qmk_firmware is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with qmk_firmware.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "jjerrell.h"
+
+bool rgb_indicators_process_keymap(uint8_t led_min, uint8_t led_max);
+bool rgb_indicators_process_layer_user(uint8_t layer, uint8_t active_mods);
+bool rgb_indicators_process_modifiers_keymap(uint8_t active_mods, uint8_t layer);
+bool rgb_indicators_process_modifiers_user(uint8_t active_mods, uint8_t layer);
+
+const uint8_t RGB_LIST_ARROWS[] = {
+#if defined(KEYBOARD_planck_ez_glow)
+    2,
+    13,
+    14,
+    15
+#elif defined(KEYBOARD_moonlander)
+    12,
+    16,
+    17,
+    22
+#endif
+};
+
+const uint8_t RGB_LIST_NUMPAD[] = {
+#if defined(KEYBOARD_planck_ez_glow)
+    8,
+    9,
+    10,
+    20,
+    21,
+    22,
+    32,
+    33,
+    34,
+    43
+#elif defined(KEYBOARD_moonlander)
+    47,
+    48,
+    49,
+    52,
+    53,
+    54,
+    57,
+    58,
+    59,
+    60
+#endif
+};
+
+// clang-format off
+#define INDEX_LSFT   0
+#define INDEX_RSFT   1
+#define INDEX_CWORD  2
+
+#define INDEX_LCMD   3
+#define INDEX_RCMD   4
+
+#define INDEX_LOPT   5
+#define INDEX_ROPT   6
+
+#define INDEX_LCTL   7
+#define INDEX_RCTL   8
+// clang-format on
+
+/* Order is important. This list will be explicitly accessed by index */
+const uint8_t RGB_LIST_MODIFIERS[] = {
+#if defined(KEYBOARD_planck_ez_glow)
+    // shift
+    13, // 0
+    22, // 1
+    // caps word
+    39,
+    // command
+    14,
+    21,
+    // option/alt
+    15,
+    20,
+    // control
+    24,
+    35
+#elif defined(KEYBOARD_moonlander)
+    // shift
+    12,
+    48,
+    // caps word
+    2,
+    // command
+    17,
+    53,
+    // option/alt
+    22,
+    58,
+    // control
+    8,
+    44
+#endif
+};

--- a/users/jjerrell/readme.md
+++ b/users/jjerrell/readme.md
@@ -1,0 +1,34 @@
+# Jacob Jerrell's Userspace
+
+Contains shared firmware implementations for re-use across multiple boards. Additionally, it provides an API for keyboard specific customizations where the `*_user` method is already in use and/or needs to provide additional state information.
+
+## RGB Notes
+
+### For split board layer state indication
+
+If necessary, in config.h:
+
+```h
+#define SPLIT_LAYER_STATE_ENABLE
+```
+
+### Identifying related light clusters
+
+In a header file:
+
+```h
+const uint8_t LED_LIST_ARROWS[] = {
+    2,
+    13,
+    14,
+    15
+};
+```
+
+In an RGB_MATRIX implementation:
+
+```c
+for (uint8_t i = 0; i < ARRAYSIZE(LED_LIST_ARROWS); i++) {
+    rgb_matrix_set_color(LED_LIST_ARROWS[i], RGB_BLUE);
+}
+```

--- a/users/jjerrell/rules.mk
+++ b/users/jjerrell/rules.mk
@@ -1,0 +1,26 @@
+SRC += $(USER_PATH)/jjerrell.c \
+    $(USER_PATH)/lighting/rgb_custom.c
+
+ifneq ($(strip $(NO_SECRETS)), yes)
+    ifneq ("$(wildcard $(USER_PATH)/secrets.c)","")
+        SRC += secrets.c
+    endif
+    ifeq ($(strip $(NO_SECRETS)), lite)
+        OPT_DEFS += -DNO_SECRETS
+    endif
+endif
+
+LEADER_ENABLE = yes
+EXTRAKEY_ENABLE = yes
+AUTOCORRECT_ENABLE = yes
+CAPS_WORD_ENABLE = yes
+
+# space savers
+LTO_ENABLE = yes
+
+# reduce firmware size -- enable where needed
+CONSOLE_ENABLE = no
+COMMAND_ENABLE = no
+MOUSEKEY_ENABLE = no
+SPACE_CADET_ENABLE = no
+GRAVE_ESC_ENABLE = no

--- a/users/jjerrell/wrappers.h
+++ b/users/jjerrell/wrappers.h
@@ -1,0 +1,75 @@
+// Copyright (C) 2023 Jerrell, Jacob <@jjerrell>
+//
+// This file is part of qmk_firmware.
+//
+// qmk_firmware is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// qmk_firmware is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with qmk_firmware.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+#include "jjerrell.h"
+
+// clang-format off
+// Workman
+#define _________________WORKMN_L1_________________ KC_Q, KC_D, KC_R,    KC_W,   KC_B
+#define _________________WORKMN_L2_________________ KC_A, KC_S, KC_H,    KC_T,   KC_G
+#define _________________WORKMN_L3_________________ KC_Z, KC_X, KC_M,    KC_C,   KC_V
+
+#define _________________WORKMN_R1_________________ KC_J, KC_F, KC_U,    KC_P,   KC_SCLN
+#define _________________WORKMN_R2_________________ KC_Y, KC_N, KC_E,    KC_O,   KC_I
+#define _________________WORKMN_R3_________________ KC_K, KC_L, KC_COMM, KC_DOT, KC_SLSH
+
+// QWERTY
+#define _________________QWERTY_L1_________________ KC_Q, KC_W, KC_E, KC_R, KC_T
+#define _________________QWERTY_L2_________________ KC_A, KC_S, KC_D, KC_F, KC_G
+#define _________________QWERTY_L3_________________ KC_Z, KC_X, KC_C, KC_V, KC_B
+
+#define _________________QWERTY_R1_________________ KC_Y, KC_U, KC_I,    KC_O,   KC_P
+#define _________________QWERTY_R2_________________ KC_H, KC_J, KC_K,    KC_L,   KC_SCLN
+#define _________________QWERTY_R3_________________ KC_N, KC_M, KC_COMM, KC_DOT, KC_SLSH
+
+// Numbers
+#define _________________NUMBERS_L_________________ KC_1, KC_2, KC_3, KC_4, KC_5
+#define _________________NUMBERS_R_________________ KC_6, KC_7, KC_8, KC_9, KC_0
+
+// Lower
+#define _________________LOWER_L1__________________ KC_PGUP, KC_TAB,  KC_UP,   KC_ENT,  KC_PGDN
+#define _________________LOWER_L2__________________ KC_HOME, KC_LEFT, KC_DOWN, KC_RGHT, KC_END
+#define _________________LOWER_L3__________________ KC_ESC,  KC_BSPC, KC_CUT,  KC_DEL,  KC_CCCV
+
+#define _________________LOWER_R1__________________ XXXXXXX, KC_7, KC_8,   KC_9,    KC_ASTR
+#define _________________LOWER_R2__________________ XXXXXXX, KC_4, KC_5,   KC_6,    KC_SLSH
+#define _________________LOWER_R3__________________ XXXXXXX, KC_1, KC_2,   KC_3,    KC_MINS
+#define          _____________LOWER_R4_____________          KC_0, KC_DOT, KC_COMM, KC_PLUS
+
+// Raise
+#define _________________RAISE_L1__________________ KC_PIPE, KC_MINS, KC_LBRC, KC_RBRC, KC_AMPR
+#define _________________RAISE_L2__________________ KC_BSLS, KC_SLSH, KC_LPRN, KC_RPRN, KC_ASTR
+#define _________________RAISE_L3__________________ KC_HASH, KC_DLR,  KC_PERC, KC_TILD, KC_GRV
+
+#define _________________RAISE_R1__________________ KC_EXLM, KC_LABK, KC_RABK, KC_UNDS, KC_SCLN
+#define _________________RAISE_R2__________________ KC_QUES, KC_LCBR, KC_RCBR, KC_EQL,  KC_COLN
+#define _________________RAISE_R3__________________ KC_AT,   KC_QUOT, KC_DQUO, KC_PLUS, KC_CIRC
+
+// Adjust
+#define _________________ADJUST_L1_________________ KC_MAKE, DB_TOGG, QK_BOOT, KC_QWERTY, KC_WRKMAN
+#define _________________ADJUST_L2_________________ KC_MUTE, KC_VOLD, KC_VOLU, KC_MPLY,   KC_MNXT
+#define _________________ADJUST_L3_________________ KC_VRSN, AU_ON,   AU_OFF,  CG_SWAP,   CG_NORM
+
+#define _________________ADJUST_R1_________________ MU_NEXT, MU_ON,   MU_OFF,  MI_ON,   MI_OFF
+#define _________________ADJUST_R2_________________ AU_NEXT, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD
+#define _________________ADJUST_R3_________________ AU_PREV, RGB_TOG, RGB_MOD, RGB_VAI, RGB_VAD
+
+// Function
+#define _______________________FROW_L_______________________ KC_F1, KC_F2, KC_F3, KC_F4,  KC_F5,  KC_F6
+#define _______________________FROW_R_______________________ KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12
+// clang-format on


### PR DESCRIPTION
## Preface

Embraces a long-term goal of QMK by shifting maintenance and organization of individuals' keymaps away from the main firmware repository. This gives us each a wide range of flexibility for approaching keymap maintenance and reduces the struggle of switching between keymap and userspace files. A notable drawback is that it isn't nearly as easy to browse others' keymaps/userspaces for inspiration; but it also provides a greater sense of ownership and an easier lens into what matters for an individual firmware user.

## Overview

Ports changes staged in my fork of the original qmk/qmk_firmware repository.

- Major userspace refactor
- Consistent approach to keymap design across keyboards
- Greater separation of concerns by keeping keyboard-specific logic or utilities with their respective keymap